### PR TITLE
don't set the application title in the library

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.rockerhieu.emojicon">
 
-    <application android:label="@string/app_name"/>
 </manifest>


### PR DESCRIPTION
I noticed the library sets a title for the application, this is better done in the Manifest of the app using the library, not in the library itself.